### PR TITLE
Integrate external bump command into dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Discord Bump Bot
 
 Minimal Discord.js bot with:
-- `/bump` slash command
-- automatic message every 2 hours in a chosen channel
+- `/bump` slash command proxy that relays to a partner bot (e.g. DISBOARD)
+- automatic triggering every few hours in a chosen channel
+- OAuth-powered dashboard to configure schedules and fire bumps instantly
 
 ## Setup
 
@@ -15,8 +16,12 @@ Minimal Discord.js bot with:
 ```
 DISCORD_BOT_TOKEN=YOUR_BOT_TOKEN
 CLIENT_ID=YOUR_APPLICATION_ID
-GUILD_ID=YOUR_TEST_GUILD_ID
-CHANNEL_ID=YOUR_TARGET_CHANNEL_ID
+CLIENT_SECRET=YOUR_OAUTH_SECRET
+REDIRECT_URI=http://localhost:3000/callback
+SESSION_SECRET=super-secret-session-key
+# Optional overrides:
+# BUMP_APPLICATION_ID=302050872383242240 (DISBOARD default)
+# BUMP_COMMAND_NAME=bump
 ```
 
 3. **Install**
@@ -24,19 +29,15 @@ CHANNEL_ID=YOUR_TARGET_CHANNEL_ID
 npm i
 ```
 
-4. **Register commands** (guild-scoped for instant availability)
-```
-npm run deploy
-```
-
-5. **Run**
+4. **Run**
 ```
 npm start
 ```
 
-6. **Use**
-- Type `/bump` in your test guild.
-- The bot will also send "Bumped! 🚀" to `CHANNEL_ID` every 2 hours.
+5. **Use**
+- Visit http://localhost:3000/login and sign in with Discord.
+- Pick a guild, select the bump channel and cadence, then hit **Trigger /bump** to relay the partner bot's command.
+- Automatic bumps reuse the same channel and interval you configure in the dashboard.
 
 ## Notes
 - Node 18+ recommended.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 import "dotenv/config";
 import express from "express";
 import session from "express-session";
-import { Client, GatewayIntentBits, Events, ChannelType } from "discord.js";
+import {
+  Client,
+  GatewayIntentBits,
+  Events,
+  ChannelType,
+  Routes,
+} from "discord.js";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -13,6 +19,8 @@ const {
   PORT = 3000,
   SESSION_SECRET = "changeme",
   DEFAULT_INTERVAL_MINUTES = "120",
+  BUMP_APPLICATION_ID = "302050872383242240",
+  BUMP_COMMAND_NAME = "bump",
 } = process.env;
 
 if (!DISCORD_BOT_TOKEN || !CLIENT_ID || !CLIENT_SECRET) {
@@ -56,16 +64,84 @@ const client = new Client({
 
 // Schedule management
 const intervals = new Map();
+const bumpCommandCache = new Map();
+
+async function fetchExternalBumpCommand(guildId) {
+  if (!BUMP_APPLICATION_ID) {
+    throw new Error("Missing BUMP_APPLICATION_ID env var");
+  }
+
+  if (bumpCommandCache.has(guildId)) {
+    return bumpCommandCache.get(guildId);
+  }
+
+  let commands = [];
+  try {
+    commands = await client.rest.get(
+      Routes.applicationGuildCommands(BUMP_APPLICATION_ID, guildId)
+    );
+  } catch (err) {
+    if (err.status !== 404) {
+      console.error("Failed to fetch guild commands", err);
+      throw err;
+    }
+  }
+
+  if (!commands?.length) {
+    try {
+      commands = await client.rest.get(Routes.applicationCommands(BUMP_APPLICATION_ID));
+    } catch (err) {
+      console.error("Failed to fetch global commands", err);
+      throw err;
+    }
+  }
+
+  const command = commands.find(
+    (cmd) => cmd?.name?.toLowerCase() === BUMP_COMMAND_NAME.toLowerCase()
+  );
+
+  if (!command) {
+    throw new Error(`Command ${BUMP_COMMAND_NAME} not found for application ${BUMP_APPLICATION_ID}`);
+  }
+
+  bumpCommandCache.set(guildId, command);
+  return command;
+}
+
+async function executeExternalBump(guildId, channelId) {
+  const sessionId = [...client.ws.shards.values()][0]?.sessionId;
+  if (!sessionId) {
+    throw new Error("Bot gateway session not ready yet");
+  }
+
+  const command = await fetchExternalBumpCommand(guildId);
+
+  await client.rest.post(Routes.interactions(), {
+    body: {
+      type: 2,
+      application_id: BUMP_APPLICATION_ID,
+      guild_id: guildId,
+      channel_id: channelId,
+      session_id: sessionId,
+      data: {
+        id: command.id,
+        type: command.type,
+        name: command.name,
+        version: command.version,
+        options: [],
+        attachments: [],
+      },
+    },
+  });
+}
 
 async function sendBump(guildId) {
   try {
     const entry = config[guildId];
     if (!entry?.channelId) return;
-    const channel = await client.channels.fetch(entry.channelId);
-    if (!channel || !channel.isTextBased()) return;
-    await channel.send(entry.message || "Bumped! 🚀");
+    await executeExternalBump(guildId, entry.channelId);
     console.log(
-      `[AUTO] Bumped in guild ${guildId} channel ${
+      `[AUTO] Triggered /${BUMP_COMMAND_NAME} for guild ${guildId} channel ${
         entry.channelId
       } at ${new Date().toISOString()}`
     );
@@ -252,6 +328,40 @@ app.post("/api/remove", loginRequired, async (req, res) => {
   if (iv) clearInterval(iv);
   intervals.delete(guildId);
   res.json({ ok: true });
+});
+
+// API: trigger bump command immediately
+app.post("/api/bump", loginRequired, async (req, res) => {
+  const { guildId } = req.body || {};
+  if (!guildId) return res.status(400).json({ error: "guildId required" });
+
+  const entry = config[guildId];
+  if (!entry?.channelId) {
+    return res
+      .status(400)
+      .json({ error: "No channel configured for this guild." });
+  }
+
+  try {
+    await executeExternalBump(guildId, entry.channelId);
+    res.json({ ok: true, message: "Bump command executed successfully!" });
+  } catch (err) {
+    const rawMessage = err?.rawError?.message || err?.message || "";
+    const isCooldown = /cooldown/i.test(rawMessage);
+    const description = isCooldown
+      ? "Failed to execute bump command: Cooldown in effect."
+      : "Failed to execute bump command.";
+    res.status(isCooldown ? 200 : 500).json({
+      ok: false,
+      cooldown: isCooldown,
+      embed: {
+        title: isCooldown
+          ? "Cooldown Active"
+          : "Bump command failed",
+        description,
+      },
+    });
+  }
 });
 
 app.listen(Number(PORT), () => {

--- a/public/style.css
+++ b/public/style.css
@@ -1,15 +1,34 @@
-*{box-sizing:border-box}body{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:#0b1220;color:#e6ecff}
-header{display:flex;justify-content:space-between;align-items:center;padding:16px 20px;background:#0f172a;border-bottom:1px solid #1f2a44}
-h1{font-size:20px;margin:0}
+*{box-sizing:border-box}
+body{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:radial-gradient(circle at top,#152448 0%,#091021 55%,#060913 100%);color:#e6ecff;min-height:100vh}
+header{display:flex;justify-content:space-between;align-items:center;padding:20px 24px;background:rgba(15,23,42,.85);backdrop-filter:blur(10px);border-bottom:1px solid rgba(148,163,184,.12);position:sticky;top:0;z-index:10}
+h1{font-size:22px;margin:0}
 .user a{color:#93c5fd}
-main{max-width:1000px;margin:24px auto;padding:0 16px;display:grid;gap:16px}
-.card{background:#0f172a;border:1px solid #1f2a44;border-radius:14px;padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
-.guild{padding:14px;border:1px solid #23314f;border-radius:12px;background:#111a2e;cursor:pointer;transition:.15s}
-.guild:hover{transform:translateY(-2px);border-color:#33528f}
-label{display:block;margin:10px 0 6px;font-weight:600;font-size:14px}
-input,select,button{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #263453;background:#0d1526;color:#e6ecff}
-button{cursor:pointer;margin-top:10px}
-button.danger{border-color:#7f1d1d;color:#fecaca}
-.row{display:flex;gap:10px}
-#status{margin-top:8px;color:#93c5fd}
+main{max-width:1100px;margin:32px auto;padding:0 20px;display:grid;gap:20px}
+.card{background:rgba(15,23,42,.92);border:1px solid rgba(148,163,184,.15);border-radius:18px;padding:20px;box-shadow:0 25px 50px -12px rgba(15,23,42,.65)}
+.card-heading{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:12px}
+.card-heading h2{margin:0;font-size:20px}
+.muted{color:#94a3b8;font-size:14px;margin:6px 0 0}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:14px;margin-top:12px}
+.guild{padding:16px;border:1px solid rgba(51,65,85,.6);border-radius:14px;background:linear-gradient(145deg,rgba(30,41,59,.9),rgba(15,23,42,.9));cursor:pointer;transition:.18s transform ease, .18s border-color ease, .18s box-shadow ease;display:flex;flex-direction:column;gap:6px}
+.guild span{font-weight:600}
+.guild:hover{transform:translateY(-3px);border-color:#60a5fa;box-shadow:0 12px 25px -15px #60a5fa}
+.field-grid{display:grid;gap:12px;margin-bottom:10px}
+@media(min-width:720px){.field-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.field-grid label:nth-child(3){grid-column:1/-1}
+label{display:block;font-weight:600;font-size:14px;color:#cbd5f5}
+input,select,button{width:100%;padding:12px 14px;border-radius:12px;border:1px solid rgba(100,116,139,.4);background:rgba(15,23,42,.75);color:#e6ecff;transition:border-color .18s ease,box-shadow .18s ease}
+input:focus,select:focus,button:focus{outline:none;border-color:#60a5fa;box-shadow:0 0 0 3px rgba(96,165,250,.15)}
+button{cursor:pointer;margin-top:0;font-weight:600;letter-spacing:.01em}
+button.accent{width:auto;background:linear-gradient(135deg,#38bdf8,#6366f1);border:none;color:#0b1220;padding:12px 20px}
+button.accent:disabled{opacity:.45;cursor:not-allowed}
+button.danger{border-color:rgba(248,113,113,.5);color:#fecaca}
+.row{display:flex;flex-wrap:wrap;gap:12px;margin-top:4px}
+.row button{flex:1 1 220px}
+.status{margin-top:16px}
+.embed{border-left:4px solid #60a5fa;background:rgba(14,22,40,.9);padding:14px 16px;border-radius:12px;box-shadow:0 10px 20px -15px rgba(96,165,250,.7)}
+.embed-title{font-weight:700;margin-bottom:6px}
+.embed-desc{color:#cbd5f5;font-size:14px;line-height:1.45}
+.embed--success{border-left-color:#34d399;box-shadow:0 10px 20px -15px rgba(52,211,153,.7)}
+.embed--error{border-left-color:#f87171;box-shadow:0 10px 20px -15px rgba(248,113,113,.7)}
+.embed--warning{border-left-color:#fbbf24;box-shadow:0 10px 20px -15px rgba(251,191,36,.7)}
+.embed--info{border-left-color:#60a5fa}

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -14,26 +14,39 @@
 
   <main>
     <section class="card">
-      <h2>Pick a server</h2>
+      <div class="card-heading">
+        <div>
+          <h2>Servers</h2>
+          <p class="muted">Select a server to adjust scheduling and trigger bumps instantly.</p>
+        </div>
+      </div>
       <div id="guilds" class="grid"></div>
     </section>
 
     <section class="card" id="config-section" hidden>
-      <h2 id="guildTitle">Configure</h2>
-      <label>Channel
-        <select id="channels"></select>
-      </label>
-      <label>Interval (minutes)
-        <input id="interval" type="number" min="1" value="120">
-      </label>
-      <label>Message
-        <input id="message" type="text" maxlength="2000" value="Bumped! 🚀">
-      </label>
+      <div class="card-heading">
+        <div>
+          <h2 id="guildTitle">Configure</h2>
+          <p class="muted">Fine tune automation, then launch the partner bot's /bump right from here.</p>
+        </div>
+        <button id="bumpBtn" class="accent" disabled>Trigger /bump</button>
+      </div>
+      <div class="field-grid">
+        <label>Channel
+          <select id="channels"></select>
+        </label>
+        <label>Interval (minutes)
+          <input id="interval" type="number" min="1" value="120">
+        </label>
+        <label>Message
+          <input id="message" type="text" maxlength="2000" value="Bumped! 🚀">
+        </label>
+      </div>
       <div class="row">
-        <button id="saveBtn">Save</button>
+        <button id="saveBtn">Save Schedule</button>
         <button id="removeBtn" class="danger">Remove Schedule</button>
       </div>
-      <div id="status"></div>
+      <div id="status" class="status"></div>
     </section>
   </main>
 
@@ -46,8 +59,23 @@
     const messageEl = document.getElementById('message');
     const saveBtn = document.getElementById('saveBtn');
     const removeBtn = document.getElementById('removeBtn');
+    const bumpBtn = document.getElementById('bumpBtn');
     const statusEl = document.getElementById('status');
     let selectedGuild = null;
+    let selectedConfig = null;
+
+    function renderStatus(variant, title, description = '') {
+      statusEl.innerHTML = `
+        <div class="embed embed--${variant}">
+          <div class="embed-title">${title}</div>
+          ${description ? `<div class="embed-desc">${description}</div>` : ''}
+        </div>
+      `;
+    }
+
+    function clearStatus() {
+      statusEl.innerHTML = '';
+    }
 
     async function loadGuilds() {
       const r = await fetch('/api/guilds');
@@ -64,9 +92,10 @@
 
     async function selectGuild(g, cfg) {
       selectedGuild = g;
+      selectedConfig = cfg || null;
       guildTitle.textContent = 'Configure: ' + (g.name || g.id);
       configSection.hidden = false;
-      statusEl.textContent = '';
+      clearStatus();
 
       const rc = await fetch('/api/channels?guild_id=' + g.id);
       const data = await rc.json();
@@ -83,6 +112,8 @@
         intervalEl.value = cfg.intervalMinutes || 120;
         messageEl.value = cfg.message || 'Bumped! 🚀';
       }
+
+      bumpBtn.disabled = !(cfg && cfg.channelId);
     }
 
     saveBtn.onclick = async () => {
@@ -93,16 +124,55 @@
         intervalMinutes: Number(intervalEl.value) || 120,
         message: messageEl.value
       };
+      renderStatus('info', 'Saving configuration…', 'Updating your automatic bump schedule.');
       const r = await fetch('/api/save', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
       const data = await r.json();
-      statusEl.textContent = data.ok ? 'Saved ✅' : 'Failed ❌';
+      if (data.ok) {
+        selectedConfig = data.config;
+        renderStatus('success', 'Schedule saved!', 'Your bump schedule is active and will use the external /bump command.');
+        bumpBtn.disabled = false;
+      } else {
+        renderStatus('error', 'Save failed', data.error || 'Please try again.');
+      }
     };
 
     removeBtn.onclick = async () => {
       if (!selectedGuild) return;
+      renderStatus('info', 'Removing schedule…');
       const r = await fetch('/api/remove', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ guildId: selectedGuild.id }) });
       const data = await r.json();
-      statusEl.textContent = data.ok ? 'Removed ✅' : 'Failed ❌';
+      if (data.ok) {
+        selectedConfig = null;
+        bumpBtn.disabled = true;
+        renderStatus('success', 'Schedule removed', 'Automation is turned off for this server.');
+      } else {
+        renderStatus('error', 'Removal failed', data.error || 'Please try again.');
+      }
+    };
+
+    bumpBtn.onclick = async () => {
+      if (!selectedGuild) return;
+      renderStatus('info', 'Triggering bump…', 'We are relaying the /bump command to the partner bot.');
+      try {
+        const r = await fetch('/api/bump', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ guildId: selectedGuild.id })
+        });
+        const data = await r.json();
+        if (data.ok) {
+          renderStatus('success', 'Bump command executed successfully!');
+        } else if (data.cooldown) {
+          const embed = data.embed || {};
+          renderStatus('warning', embed.title || 'Cooldown in effect', embed.description || 'The partner bot reported a cooldown.');
+        } else {
+          const embed = data.embed || {};
+          renderStatus('error', embed.title || 'Bump command failed', embed.description || 'Please check the bot permissions and try again.');
+        }
+      } catch (err) {
+        console.error(err);
+        renderStatus('error', 'Unexpected error', 'Something went wrong while calling /bump.');
+      }
     };
 
     loadGuilds();


### PR DESCRIPTION
## Summary
- add backend helpers to proxy the partner bot's /bump slash command and expose a dashboard API
- enhance the dashboard with an instant bump trigger, embed-style feedback, and refreshed visuals
- document the new environment variables and usage flow for the upgraded dashboard

## Testing
- not run (Discord credentials required)


------
https://chatgpt.com/codex/tasks/task_e_68d023a58a8c8330868ac7d34cb152f4