### PR TITLE
Add polished marketing landing and legal pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Discord Bump Bot
 
 Minimal Discord.js bot with:
-- `/bump` slash command
-- automatic message every 2 hours in a chosen channel
+- `/bump` slash command proxy that relays to a partner bot (e.g. DISBOARD)
+- automatic triggering every few hours in a chosen channel
+- OAuth-powered dashboard to configure schedules and fire bumps instantly
 
 ## Setup
 
@@ -15,8 +16,12 @@ Minimal Discord.js bot with:
 ```
 DISCORD_BOT_TOKEN=YOUR_BOT_TOKEN
 CLIENT_ID=YOUR_APPLICATION_ID
-GUILD_ID=YOUR_TEST_GUILD_ID
-CHANNEL_ID=YOUR_TARGET_CHANNEL_ID
+CLIENT_SECRET=YOUR_OAUTH_SECRET
+REDIRECT_URI=http://localhost:3000/callback
+SESSION_SECRET=super-secret-session-key
+# Optional overrides:
+# BUMP_APPLICATION_ID=302050872383242240 (DISBOARD default)
+# BUMP_COMMAND_NAME=bump
 ```
 
 3. **Install**
@@ -24,19 +29,15 @@ CHANNEL_ID=YOUR_TARGET_CHANNEL_ID
 npm i
 ```
 
-4. **Register commands** (guild-scoped for instant availability)
-```
-npm run deploy
-```
-
-5. **Run**
+4. **Run**
 ```
 npm start
 ```
 
-6. **Use**
-- Type `/bump` in your test guild.
-- The bot will also send "Bumped! 🚀" to `CHANNEL_ID` every 2 hours.
+5. **Use**
+- Visit http://localhost:3000/login and sign in with Discord.
+- Pick a guild, select the bump channel and cadence, then hit **Trigger /bump** to relay the partner bot's command.
+- Automatic bumps reuse the same channel and interval you configure in the dashboard.
 
 ## Notes
 - Node 18+ recommended.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 import "dotenv/config";
 import express from "express";
 import session from "express-session";
-import { Client, GatewayIntentBits, Events, ChannelType } from "discord.js";
+import {
+  Client,
+  GatewayIntentBits,
+  Events,
+  ChannelType,
+  Routes,
+} from "discord.js";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -13,6 +19,8 @@ const {
   PORT = 3000,
   SESSION_SECRET = "changeme",
   DEFAULT_INTERVAL_MINUTES = "120",
+  BUMP_APPLICATION_ID = "302050872383242240",
+  BUMP_COMMAND_NAME = "bump",
 } = process.env;
 
 if (!DISCORD_BOT_TOKEN || !CLIENT_ID || !CLIENT_SECRET) {
@@ -56,16 +64,105 @@ const client = new Client({
 
 // Schedule management
 const intervals = new Map();
+const bumpCommandCache = new Map();
+
+async function fetchExternalBumpCommand(guildId) {
+  if (!BUMP_APPLICATION_ID) {
+    throw new Error("Missing BUMP_APPLICATION_ID env var");
+  }
+
+  if (bumpCommandCache.has(guildId)) {
+    return bumpCommandCache.get(guildId);
+  }
+
+  let commands = [];
+  try {
+    commands = await client.rest.get(
+      Routes.applicationGuildCommands(BUMP_APPLICATION_ID, guildId)
+    );
+  } catch (err) {
+    if (err.status !== 404) {
+      console.error("Failed to fetch guild commands", err);
+      throw err;
+    }
+  }
+
+  if (!commands?.length) {
+    try {
+      commands = await client.rest.get(Routes.applicationCommands(BUMP_APPLICATION_ID));
+    } catch (err) {
+      console.error("Failed to fetch global commands", err);
+      throw err;
+    }
+  }
+
+  const command = commands.find(
+    (cmd) => cmd?.name?.toLowerCase() === BUMP_COMMAND_NAME.toLowerCase()
+  );
+
+  if (!command) {
+    throw new Error(`Command ${BUMP_COMMAND_NAME} not found for application ${BUMP_APPLICATION_ID}`);
+  }
+
+  bumpCommandCache.set(guildId, command);
+  return command;
+}
+
+async function executeExternalBump(guildId, channelId) {
+  const sessionId = [...client.ws.shards.values()][0]?.sessionId;
+  if (!sessionId) {
+    throw new Error("Bot gateway session not ready yet");
+  }
+
+  const command = await fetchExternalBumpCommand(guildId);
+
+  const response = await fetch("https://discord.com/api/v10/interactions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      type: 2,
+      application_id: BUMP_APPLICATION_ID,
+      guild_id: guildId,
+      channel_id: channelId,
+      session_id: sessionId,
+      nonce: Date.now().toString(),
+      data: {
+        id: command.id,
+        type: command.type,
+        name: command.name,
+        version: command.version,
+        options: [],
+        attachments: [],
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    let details = null;
+    try {
+      details = await response.json();
+    } catch (e) {
+      // ignore json parse issues
+    }
+    const error = new Error(
+      details?.message || `Discord API error ${response.status}`
+    );
+    error.status = response.status;
+    error.rawError = details;
+    throw error;
+  }
+}
 
 async function sendBump(guildId) {
   try {
     const entry = config[guildId];
     if (!entry?.channelId) return;
-    const channel = await client.channels.fetch(entry.channelId);
-    if (!channel || !channel.isTextBased()) return;
-    await channel.send(entry.message || "Bumped! 🚀");
+    await executeExternalBump(guildId, entry.channelId);
     console.log(
-      `[AUTO] Bumped in guild ${guildId} channel ${
+      `[AUTO] Triggered /${BUMP_COMMAND_NAME} for guild ${guildId} channel ${
         entry.channelId
       } at ${new Date().toISOString()}`
     );
@@ -116,7 +213,21 @@ function loginRequired(req, res, next) {
 
 // Routes
 app.get("/", (req, res) => {
-  res.redirect("/dashboard");
+  res.render("landing", {
+    user: req.session.user || null,
+  });
+});
+
+app.get("/terms", (req, res) => {
+  res.render("terms", {
+    user: req.session.user || null,
+  });
+});
+
+app.get("/privacy", (req, res) => {
+  res.render("privacy", {
+    user: req.session.user || null,
+  });
 });
 
 app.get("/login", (req, res) => {
@@ -252,6 +363,40 @@ app.post("/api/remove", loginRequired, async (req, res) => {
   if (iv) clearInterval(iv);
   intervals.delete(guildId);
   res.json({ ok: true });
+});
+
+// API: trigger bump command immediately
+app.post("/api/bump", loginRequired, async (req, res) => {
+  const { guildId } = req.body || {};
+  if (!guildId) return res.status(400).json({ error: "guildId required" });
+
+  const entry = config[guildId];
+  if (!entry?.channelId) {
+    return res
+      .status(400)
+      .json({ error: "No channel configured for this guild." });
+  }
+
+  try {
+    await executeExternalBump(guildId, entry.channelId);
+    res.json({ ok: true, message: "Bump command executed successfully!" });
+  } catch (err) {
+    const rawMessage = err?.rawError?.message || err?.message || "";
+    const isCooldown = /cooldown/i.test(rawMessage);
+    const description = isCooldown
+      ? "Failed to execute bump command: Cooldown in effect."
+      : "Failed to execute bump command.";
+    res.status(isCooldown ? 200 : 500).json({
+      ok: false,
+      cooldown: isCooldown,
+      embed: {
+        title: isCooldown
+          ? "Cooldown Active"
+          : "Bump command failed",
+        description,
+      },
+    });
+  }
 });
 
 app.listen(Number(PORT), () => {

--- a/public/style.css
+++ b/public/style.css
@@ -1,15 +1,502 @@
-*{box-sizing:border-box}body{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:#0b1220;color:#e6ecff}
-header{display:flex;justify-content:space-between;align-items:center;padding:16px 20px;background:#0f172a;border-bottom:1px solid #1f2a44}
-h1{font-size:20px;margin:0}
-.user a{color:#93c5fd}
-main{max-width:1000px;margin:24px auto;padding:0 16px;display:grid;gap:16px}
-.card{background:#0f172a;border:1px solid #1f2a44;border-radius:14px;padding:16px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px}
-.guild{padding:14px;border:1px solid #23314f;border-radius:12px;background:#111a2e;cursor:pointer;transition:.15s}
-.guild:hover{transform:translateY(-2px);border-color:#33528f}
-label{display:block;margin:10px 0 6px;font-weight:600;font-size:14px}
-input,select,button{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #263453;background:#0d1526;color:#e6ecff}
-button{cursor:pointer;margin-top:10px}
-button.danger{border-color:#7f1d1d;color:#fecaca}
-.row{display:flex;gap:10px}
-#status{margin-top:8px;color:#93c5fd}
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  margin: 0;
+  background: radial-gradient(circle at top, #152448 0%, #091021 55%, #060913 100%);
+  color: #e6ecff;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  gap: 20px;
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 700;
+  color: #bfdbfe;
+  letter-spacing: 0.01em;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  color: #cbd5f5;
+  font-size: 15px;
+}
+
+.nav-links a {
+  padding: 6px 10px;
+  border-radius: 999px;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.nav-links a:hover {
+  background: rgba(148, 163, 184, 0.15);
+  text-decoration: none;
+}
+
+.auth, .user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: #cbd5f5;
+}
+
+.chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: #e0f2fe;
+  font-weight: 600;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0b1220;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.btn.small {
+  padding: 9px 16px;
+  font-size: 14px;
+}
+
+.btn.secondary {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #e6ecff;
+}
+
+.btn:hover {
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px -10px rgba(59, 130, 246, 0.7);
+}
+
+body.dashboard main {
+  max-width: 1100px;
+  margin: 32px auto;
+  padding: 0 20px 48px;
+  display: grid;
+  gap: 20px;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.65);
+}
+
+.card-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.card-heading h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.muted {
+  color: #94a3b8;
+  font-size: 14px;
+  margin: 6px 0 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 14px;
+  margin-top: 12px;
+}
+
+.guild {
+  padding: 16px;
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  border-radius: 14px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.9));
+  cursor: pointer;
+  transition: 0.18s transform ease, 0.18s border-color ease, 0.18s box-shadow ease;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.guild span {
+  font-weight: 600;
+}
+
+.guild:hover {
+  transform: translateY(-3px);
+  border-color: #60a5fa;
+  box-shadow: 0 12px 25px -15px #60a5fa;
+}
+
+.field-grid {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+@media (min-width: 720px) {
+  .field-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.field-grid label:nth-child(3) {
+  grid-column: 1 / -1;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  font-size: 14px;
+  color: #cbd5f5;
+}
+
+input,
+select,
+button {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  background: rgba(15, 23, 42, 0.75);
+  color: #e6ecff;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+input:focus,
+select:focus,
+button:focus {
+  outline: none;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+}
+
+button {
+  cursor: pointer;
+  margin-top: 0;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+button.accent {
+  width: auto;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  border: none;
+  color: #0b1220;
+  padding: 12px 20px;
+}
+
+button.accent:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button.danger {
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fecaca;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.row button {
+  flex: 1 1 220px;
+}
+
+.status {
+  margin-top: 16px;
+}
+
+.embed {
+  border-left: 4px solid #60a5fa;
+  background: rgba(14, 22, 40, 0.9);
+  padding: 14px 16px;
+  border-radius: 12px;
+  box-shadow: 0 10px 20px -15px rgba(96, 165, 250, 0.7);
+}
+
+.embed-title {
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.embed-desc {
+  color: #cbd5f5;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.embed--success {
+  border-left-color: #34d399;
+  box-shadow: 0 10px 20px -15px rgba(52, 211, 153, 0.7);
+}
+
+.embed--error {
+  border-left-color: #f87171;
+  box-shadow: 0 10px 20px -15px rgba(248, 113, 113, 0.7);
+}
+
+.embed--warning {
+  border-left-color: #fbbf24;
+  box-shadow: 0 10px 20px -15px rgba(251, 191, 36, 0.7);
+}
+
+.embed--info {
+  border-left-color: #60a5fa;
+}
+
+body.landing main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 56px 20px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 12px;
+  color: #93c5fd;
+  font-weight: 600;
+}
+
+.hero {
+  display: grid;
+  gap: 24px;
+  text-align: center;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(38px, 6vw, 60px);
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.hero p {
+  margin: 0 auto;
+  max-width: 640px;
+  color: #cbd5f5;
+  font-size: 18px;
+  line-height: 1.6;
+}
+
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.section-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.section-subtitle {
+  text-align: center;
+  color: #94a3b8;
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.feature-card {
+  padding: 22px;
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(14, 22, 40, 0.92), rgba(15, 23, 42, 0.8));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 20px 40px -24px rgba(59, 130, 246, 0.6);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 18px;
+}
+
+.feature-card p {
+  margin: 0;
+  color: #cbd5f5;
+  line-height: 1.55;
+}
+
+.gradient-card {
+  padding: 30px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(99, 102, 241, 0.18));
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  display: grid;
+  gap: 16px;
+  text-align: center;
+}
+
+.gradient-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #dbeafe;
+}
+
+.gradient-card li strong {
+  color: #bfdbfe;
+}
+
+.steps {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.steps li {
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  line-height: 1.6;
+}
+
+.steps strong {
+  color: #bfdbfe;
+}
+
+footer {
+  padding: 32px 24px 48px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 14px;
+}
+
+footer a {
+  color: #bfdbfe;
+}
+
+body.legal main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 56px 20px 80px;
+}
+
+.legal-card {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 30px 50px -25px rgba(15, 23, 42, 0.65);
+}
+
+.legal-card h1 {
+  margin-top: 0;
+  font-size: 34px;
+}
+
+.legal-card h2 {
+  margin-top: 32px;
+  font-size: 22px;
+}
+
+.legal-card p,
+.legal-card li {
+  color: #cbd5f5;
+  line-height: 1.65;
+}
+
+.legal-card ul {
+  padding-left: 20px;
+  margin: 12px 0;
+}
+
+.legal-card li + li {
+  margin-top: 6px;
+}
+
+@media (max-width: 720px) {
+  .topbar {
+    flex-wrap: wrap;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .nav-links {
+    order: 3;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .auth, .user {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .brand {
+    width: 100%;
+    text-align: center;
+  }
+
+  body.dashboard main {
+    margin-top: 24px;
+  }
+}

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -6,34 +6,55 @@
   <title>Discord Bump Dashboard</title>
   <link rel="stylesheet" href="/style.css">
 </head>
-<body>
-  <header>
-    <h1>Discord Bump Dashboard</h1>
-    <div class="user">Logged in as <strong><%= user.username %></strong> | <a href="/logout">Logout</a></div>
+<body class="dashboard">
+  <header class="topbar">
+    <a class="brand" href="/">AutoBump</a>
+    <nav class="nav-links">
+      <a href="/">Home</a>
+      <a href="/terms">Terms</a>
+      <a href="/privacy">Privacy</a>
+    </nav>
+    <div class="user">
+      <span class="chip">Logged in as <strong><%= user.username %></strong></span>
+      <a class="btn small secondary" href="/logout">Logout</a>
+    </div>
   </header>
 
   <main>
     <section class="card">
-      <h2>Pick a server</h2>
+      <div class="card-heading">
+        <div>
+          <h2>Servers</h2>
+          <p class="muted">Select a server to adjust scheduling and trigger bumps instantly.</p>
+        </div>
+      </div>
       <div id="guilds" class="grid"></div>
     </section>
 
     <section class="card" id="config-section" hidden>
-      <h2 id="guildTitle">Configure</h2>
-      <label>Channel
-        <select id="channels"></select>
-      </label>
-      <label>Interval (minutes)
-        <input id="interval" type="number" min="1" value="120">
-      </label>
-      <label>Message
-        <input id="message" type="text" maxlength="2000" value="Bumped! 🚀">
-      </label>
+      <div class="card-heading">
+        <div>
+          <h2 id="guildTitle">Configure</h2>
+          <p class="muted">Fine tune automation, then launch the partner bot's /bump right from here.</p>
+        </div>
+        <button id="bumpBtn" class="accent" disabled>Trigger /bump</button>
+      </div>
+      <div class="field-grid">
+        <label>Channel
+          <select id="channels"></select>
+        </label>
+        <label>Interval (minutes)
+          <input id="interval" type="number" min="1" value="120">
+        </label>
+        <label>Message
+          <input id="message" type="text" maxlength="2000" value="Bumped! 🚀">
+        </label>
+      </div>
       <div class="row">
-        <button id="saveBtn">Save</button>
+        <button id="saveBtn">Save Schedule</button>
         <button id="removeBtn" class="danger">Remove Schedule</button>
       </div>
-      <div id="status"></div>
+      <div id="status" class="status"></div>
     </section>
   </main>
 
@@ -46,8 +67,23 @@
     const messageEl = document.getElementById('message');
     const saveBtn = document.getElementById('saveBtn');
     const removeBtn = document.getElementById('removeBtn');
+    const bumpBtn = document.getElementById('bumpBtn');
     const statusEl = document.getElementById('status');
     let selectedGuild = null;
+    let selectedConfig = null;
+
+    function renderStatus(variant, title, description = '') {
+      statusEl.innerHTML = `
+        <div class="embed embed--${variant}">
+          <div class="embed-title">${title}</div>
+          ${description ? `<div class="embed-desc">${description}</div>` : ''}
+        </div>
+      `;
+    }
+
+    function clearStatus() {
+      statusEl.innerHTML = '';
+    }
 
     async function loadGuilds() {
       const r = await fetch('/api/guilds');
@@ -64,9 +100,10 @@
 
     async function selectGuild(g, cfg) {
       selectedGuild = g;
+      selectedConfig = cfg || null;
       guildTitle.textContent = 'Configure: ' + (g.name || g.id);
       configSection.hidden = false;
-      statusEl.textContent = '';
+      clearStatus();
 
       const rc = await fetch('/api/channels?guild_id=' + g.id);
       const data = await rc.json();
@@ -83,6 +120,8 @@
         intervalEl.value = cfg.intervalMinutes || 120;
         messageEl.value = cfg.message || 'Bumped! 🚀';
       }
+
+      bumpBtn.disabled = !(cfg && cfg.channelId);
     }
 
     saveBtn.onclick = async () => {
@@ -93,16 +132,55 @@
         intervalMinutes: Number(intervalEl.value) || 120,
         message: messageEl.value
       };
+      renderStatus('info', 'Saving configuration…', 'Updating your automatic bump schedule.');
       const r = await fetch('/api/save', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
       const data = await r.json();
-      statusEl.textContent = data.ok ? 'Saved ✅' : 'Failed ❌';
+      if (data.ok) {
+        selectedConfig = data.config;
+        renderStatus('success', 'Schedule saved!', 'Your bump schedule is active and will use the external /bump command.');
+        bumpBtn.disabled = false;
+      } else {
+        renderStatus('error', 'Save failed', data.error || 'Please try again.');
+      }
     };
 
     removeBtn.onclick = async () => {
       if (!selectedGuild) return;
+      renderStatus('info', 'Removing schedule…');
       const r = await fetch('/api/remove', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ guildId: selectedGuild.id }) });
       const data = await r.json();
-      statusEl.textContent = data.ok ? 'Removed ✅' : 'Failed ❌';
+      if (data.ok) {
+        selectedConfig = null;
+        bumpBtn.disabled = true;
+        renderStatus('success', 'Schedule removed', 'Automation is turned off for this server.');
+      } else {
+        renderStatus('error', 'Removal failed', data.error || 'Please try again.');
+      }
+    };
+
+    bumpBtn.onclick = async () => {
+      if (!selectedGuild) return;
+      renderStatus('info', 'Triggering bump…', 'We are relaying the /bump command to the partner bot.');
+      try {
+        const r = await fetch('/api/bump', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ guildId: selectedGuild.id })
+        });
+        const data = await r.json();
+        if (data.ok) {
+          renderStatus('success', 'Bump command executed successfully!');
+        } else if (data.cooldown) {
+          const embed = data.embed || {};
+          renderStatus('warning', embed.title || 'Cooldown in effect', embed.description || 'The partner bot reported a cooldown.');
+        } else {
+          const embed = data.embed || {};
+          renderStatus('error', embed.title || 'Bump command failed', embed.description || 'Please check the bot permissions and try again.');
+        }
+      } catch (err) {
+        console.error(err);
+        renderStatus('error', 'Unexpected error', 'Something went wrong while calling /bump.');
+      }
     };
 
     loadGuilds();

--- a/views/landing.ejs
+++ b/views/landing.ejs
@@ -1,0 +1,85 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AutoBump | Discord Bump Automation</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="landing">
+  <header class="topbar">
+    <a class="brand" href="/">AutoBump</a>
+    <nav class="nav-links">
+      <a href="/">Home</a>
+      <a href="/terms">Terms</a>
+      <a href="/privacy">Privacy</a>
+    </nav>
+    <div class="auth">
+      <% if (user) { %>
+        <span class="chip">Signed in as <strong><%= user.username %></strong></span>
+        <a class="btn small secondary" href="/dashboard">Open Dashboard</a>
+      <% } else { %>
+        <a class="btn small" href="/login">Login with Discord</a>
+      <% } %>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="eyebrow">Automated Discord Growth</div>
+      <h1>Keep your server trending with effortless bump automation.</h1>
+      <p>
+        AutoBump relays the partner bot's <code>/bump</code> command on schedule or on-demand.
+        No custom slash commands to maintain—just a streamlined dashboard, instant cooldown-aware feedback,
+        and a gorgeous interface your staff will love.
+      </p>
+      <div class="cta-buttons">
+        <a class="btn" href="<%= user ? '/dashboard' : '/login' %>">Launch dashboard</a>
+        <a class="btn secondary" href="#how-it-works">How it works</a>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="section-title">Why community managers pick AutoBump</h2>
+      <p class="section-subtitle">Purpose-built tooling for server discovery teams that demand reliability, clarity, and polish.</p>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h3>Slash command proxy</h3>
+          <p>Trigger the partner bot&rsquo;s <code>/bump</code> command directly—no brittle mirrors or extra permissions required.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Cooldown awareness</h3>
+          <p>Beautiful embed-style messaging keeps staff informed with instant feedback when the partner bot reports a cooldown.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Adaptive scheduling</h3>
+          <p>Configure per-guild cadence, channels, and custom confirmation copy in seconds through the responsive dashboard.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Battle-tested</h3>
+          <p>Designed for high traffic scenarios with graceful handling, resilient caching, and transparent error reporting.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="how-it-works" class="gradient-card">
+      <div class="eyebrow">How it works</div>
+      <h2 class="section-title">Launch in three simple steps</h2>
+      <ul class="steps">
+        <li><strong>Connect with Discord.</strong> Authorize AutoBump to access your guilds using OAuth2 in one secure flow.</li>
+        <li><strong>Pick a channel &amp; cadence.</strong> Choose where <code>/bump</code> should run and fine tune the interval for each community.</li>
+        <li><strong>Monitor success.</strong> Relay bumps instantly, get cooldown alerts in the dashboard, and keep your listings on top.</li>
+      </ul>
+      <div class="cta-buttons">
+        <a class="btn" href="<%= user ? '/dashboard' : '/login' %>">Get started</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    &copy; <%= new Date().getFullYear() %> AutoBump. All rights reserved. &bull;
+    <a href="/terms">Terms of Service</a> &bull;
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
+</body>
+</html>

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AutoBump | Privacy Policy</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="legal">
+  <header class="topbar">
+    <a class="brand" href="/">AutoBump</a>
+    <nav class="nav-links">
+      <a href="/">Home</a>
+      <a href="/terms">Terms</a>
+      <a href="/privacy">Privacy</a>
+    </nav>
+    <div class="auth">
+      <% if (user) { %>
+        <span class="chip">Signed in as <strong><%= user.username %></strong></span>
+        <a class="btn small secondary" href="/dashboard">Open Dashboard</a>
+      <% } else { %>
+        <a class="btn small" href="/login">Login with Discord</a>
+      <% } %>
+    </div>
+  </header>
+
+  <main>
+    <article class="legal-card">
+      <h1>Privacy Policy</h1>
+      <p>This Privacy Policy explains how AutoBump collects, uses, and safeguards information when you use the Service. By accessing the dashboard or running the bot you consent to the practices described here.</p>
+
+      <h2>1. Information we collect</h2>
+      <ul>
+        <li><strong>Discord account details:</strong> Username, ID, and guild list provided by Discord OAuth2.</li>
+        <li><strong>Configuration data:</strong> Guild IDs, selected text channel IDs, interval minutes, and optional confirmation message copy.</li>
+        <li><strong>Operational metadata:</strong> Non-sensitive logs used to monitor the health of scheduled bumps and API communication.</li>
+      </ul>
+
+      <h2>2. How we use information</h2>
+      <p>We use collected information to authenticate you, display eligible servers, store your automation preferences, and execute the partner bot&rsquo;s <code>/bump</code> command on schedule. Logs are used strictly for debugging and ensuring reliability during peak usage.</p>
+
+      <h2>3. Data retention</h2>
+      <p>Configuration data is stored until you remove a guild from the dashboard or delete your schedules. Session data persists only for the duration of your authenticated browser session.</p>
+
+      <h2>4. Sharing of information</h2>
+      <p>We do not sell or rent your information. Data is shared only with Discord&rsquo;s APIs and the partner bump bot as required to deliver the Service.</p>
+
+      <h2>5. Security</h2>
+      <p>We implement reasonable safeguards—including scoped bot permissions, session protection, and command caching—to protect your data from unauthorized access or disclosure.</p>
+
+      <h2>6. Your choices</h2>
+      <ul>
+        <li>Revoke dashboard access at any time by logging out or revoking the OAuth2 grant on Discord.</li>
+        <li>Delete stored schedules via the dashboard to remove guild-specific configuration.</li>
+        <li>Remove the bot from your server to halt further automation.</li>
+      </ul>
+
+      <h2>7. Changes to this policy</h2>
+      <p>We may update this Privacy Policy periodically. We will post revisions on this page with an updated effective date. Continued use of the Service after changes take effect indicates your acceptance.</p>
+
+      <p><strong>Effective date:</strong> <%= new Date().toLocaleDateString() %></p>
+    </article>
+  </main>
+
+  <footer>
+    &copy; <%= new Date().getFullYear() %> AutoBump. All rights reserved. &bull;
+    <a href="/terms">Terms of Service</a> &bull;
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
+</body>
+</html>

--- a/views/terms.ejs
+++ b/views/terms.ejs
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AutoBump | Terms of Service</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="legal">
+  <header class="topbar">
+    <a class="brand" href="/">AutoBump</a>
+    <nav class="nav-links">
+      <a href="/">Home</a>
+      <a href="/terms">Terms</a>
+      <a href="/privacy">Privacy</a>
+    </nav>
+    <div class="auth">
+      <% if (user) { %>
+        <span class="chip">Signed in as <strong><%= user.username %></strong></span>
+        <a class="btn small secondary" href="/dashboard">Open Dashboard</a>
+      <% } else { %>
+        <a class="btn small" href="/login">Login with Discord</a>
+      <% } %>
+    </div>
+  </header>
+
+  <main>
+    <article class="legal-card">
+      <h1>Terms of Service</h1>
+      <p>These Terms of Service ("Terms") govern your access to and use of the AutoBump dashboard, automation bot, and any related services (collectively, the "Service"). By using the Service you agree to be bound by these Terms.</p>
+
+      <h2>1. Eligibility</h2>
+      <p>You must comply with Discord&rsquo;s Terms of Service and Community Guidelines. You are responsible for ensuring that AutoBump is only connected to servers where you have permission to manage integrations.</p>
+
+      <h2>2. Acceptable use</h2>
+      <ul>
+        <li>Do not interfere with or abuse the Service, Discord&rsquo;s APIs, or the partner bump bot.</li>
+        <li>Do not attempt to reverse engineer, redistribute, or resell the Service.</li>
+        <li>Do not use the Service to automate actions that violate Discord or partner bot rules.</li>
+      </ul>
+
+      <h2>3. Scheduling and automation</h2>
+      <p>You acknowledge that bump scheduling relies on the availability and uptime of Discord and the partner bump bot. AutoBump relays commands on your behalf but cannot guarantee successful execution if upstream services are unavailable or enforce cooldowns.</p>
+
+      <h2>4. Data ownership</h2>
+      <p>You retain ownership of your Discord account, servers, and any messages you author. AutoBump stores minimal configuration data—such as selected guilds, channel IDs, and interval preferences—to provide the Service.</p>
+
+      <h2>5. Termination</h2>
+      <p>We may suspend or terminate access to the Service at any time if you breach these Terms or if continued operation is no longer commercially reasonable. You may stop using the Service at any time by removing the bot and deleting stored schedules.</p>
+
+      <h2>6. Disclaimer</h2>
+      <p>The Service is provided "as is" without warranties of any kind. We disclaim all implied warranties, including merchantability, fitness for a particular purpose, and non-infringement.</p>
+
+      <h2>7. Limitation of liability</h2>
+      <p>To the maximum extent permitted by law, AutoBump shall not be liable for indirect, incidental, consequential, or punitive damages, or any loss of profits or data, arising from your use of the Service.</p>
+
+      <h2>8. Changes to these Terms</h2>
+      <p>We may modify these Terms from time to time. Updates will be posted on this page with a revised "Last updated" date. Continued use of the Service after changes become effective constitutes acceptance of the revised Terms.</p>
+
+      <p><strong>Last updated:</strong> <%= new Date().toLocaleDateString() %></p>
+    </article>
+  </main>
+
+  <footer>
+    &copy; <%= new Date().getFullYear() %> AutoBump. All rights reserved. &bull;
+    <a href="/terms">Terms of Service</a> &bull;
+    <a href="/privacy">Privacy Policy</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a public marketing landing page and top-level navigation that links to the dashboard and legal docs
- create dedicated terms of service and privacy policy pages styled to match the refreshed visual theme
- expand shared styling with hero, feature, and legal layouts while preserving the existing dashboard UX

## Testing
- not run (Discord credentials required for `npm start`)


------
https://chatgpt.com/codex/tasks/task_e_68d023a58a8c8330868ac7d34cb152f4