### PR TITLE
Trigger Disboard bump command from slash command

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { REST, Routes, SlashCommandBuilder } from 'discord.js';
+import { REST, Routes, SlashCommandBuilder, ChannelType } from 'discord.js';
 
 const { DISCORD_BOT_TOKEN, CLIENT_ID, GUILD_ID } = process.env;
 
@@ -11,7 +11,14 @@ if (!DISCORD_BOT_TOKEN || !CLIENT_ID) {
 const commands = [
   new SlashCommandBuilder()
     .setName('bump')
-    .setDescription('Bump now.')
+    .setDescription('Trigger the Disboard bump command in a channel.')
+    .addChannelOption((option) =>
+      option
+        .setName('channel')
+        .setDescription('Channel to trigger the Disboard bump command in.')
+        .addChannelTypes(ChannelType.GuildText)
+        .setRequired(false)
+    )
     .toJSON()
 ];
 


### PR DESCRIPTION
## Summary
- invoke the external Disboard bump command when the custom /bump slash command is used in a guild
- allow specifying an override channel via the slash command and respond with helpful errors
- add a channel option to the deployed slash command definition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d979b9a7e8833083721aaca518842e