### PR TITLE
Fix syntax error in external bump request

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,23 +224,8 @@ async function executeExternalBump(guildId, channelId) {
         options: [],
         attachments: [],
       },
-    }),
+    },
   });
-
-  if (!response.ok) {
-    let details = null;
-    try {
-      details = await response.json();
-    } catch (e) {
-      // ignore json parse issues
-    }
-    const error = new Error(
-      details?.message || `Discord API error ${response.status}`
-    );
-    error.status = response.status;
-    error.rawError = details;
-    throw error;
-  }
 }
 
 async function sendBump(guildId) {


### PR DESCRIPTION
## Summary
- remove the extra parenthesis in the interaction request payload to resolve the syntax error
- drop unreachable response handling that referenced an undefined variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e181a6bb9483308c6a14130f2f7c65